### PR TITLE
new callback types

### DIFF
--- a/callbacks/SubscribeToEvents.json
+++ b/callbacks/SubscribeToEvents.json
@@ -40,5 +40,131 @@
         }
       }
     }
+  },
+  "account_charge": {
+    "{$request.body#/webhook_url}": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "./../schemas/CreateChargeInput.json"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Your server returns this code if it accepts the webhook."
+          }
+        }
+      }
+    }
+  },
+  "account_payment": {
+    "{$request.body#/webhook_url}": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "./../schemas/CreatePaymentInput.json"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Your server returns this code if it accepts the webhook."
+          }
+        }
+      }
+    }
+  },
+  "account_status_change": {
+    "{$request.body#/webhook_url}": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "./../schemas/Account.json"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Your server returns this code if it accepts the webhook."
+          }
+        }
+      }
+    }
+  },
+  "account_payment_due": {
+    "{$request.body#/webhook_url}": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "./../schemas/Account.json"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Your server returns this code if it accepts the webhook."
+          }
+        }
+      }
+    }
+  },
+  "account_fee": {
+    "{$request.body#/webhook_url}": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "./../schemas/LineItem.json"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Your server returns this code if it accepts the webhook."
+          }
+        }
+      }
+    }
+  },
+  "account_total_balance_change": {
+    "{$request.body#/webhook_url}": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "./../schemas/Account.json"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Your server returns this code if it accepts the webhook."
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Description of the change
**Added new callback types to list of supported callbacks**

- Charge
    - FD requested — updates their tx history & email customer
- Payment (including made via autopay)
    - FD requested — updates their tx history & email customer — email customer payment details
- Account status change
    - email customer; lets them know to take action on account
    - prev status, new status
- Payment due
    - start hardcoded to x days before; eventually make configurable
- Fee incurred
    - fee type should be included
- Account total balance change
    - later can add configurates on when this notif gets triggered


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
