### PR TITLE
Remove repay_configs from required, change default payment method field name

### DIFF
--- a/schemas/PaymentProcessorConfig.json
+++ b/schemas/PaymentProcessorConfig.json
@@ -5,8 +5,7 @@
       "type": "object",
       "description": "ACH processing configuration.",
       "required": [
-        "payment_processor_name",
-        "repay_config"
+        "payment_processor_name"
       ],
       "properties": {
         "payment_processor_name": {
@@ -33,8 +32,7 @@
       "type": "object",
       "description": "Debit processing configuration.",
       "required": [
-        "payment_processor_name",
-        "repay_config"
+        "payment_processor_name"
       ],
       "properties": {
         "payment_processor_name": {
@@ -66,7 +64,7 @@
           "example": true,
           "default": false
         },
-        "default_payment_processor": {
+        "default_payment_processor_method": {
           "type": "string",
           "enum": ["ACH", "DEBIT_CARD", "NONE"],
           "description": "Configures the payment processor to be used for manual or autopay payments. This cannot be set to a value different from `NONE` if no valid ACH or Debit Card configs are provided.",

--- a/schemas/PaymentProcessorConfigInput.json
+++ b/schemas/PaymentProcessorConfigInput.json
@@ -5,8 +5,7 @@
       "type": "object",
       "description": "ACH processing configuration.",
       "required": [
-        "payment_processor_name",
-        "repay_config"
+        "payment_processor_name"
       ],
       "properties": {
         "payment_processor_name": {
@@ -63,8 +62,7 @@
       "type": "object",
       "description": "Debit processing configuration.",
       "required": [
-        "payment_processor_name",
-        "repay_config"
+        "payment_processor_name"
       ],
       "properties": {
         "payment_processor_name": {
@@ -130,7 +128,7 @@
           "example": true,
           "default": false
         },
-        "default_payment_processor": {
+        "default_payment_processor_method": {
           "type": "string",
           "enum": ["ACH", "DEBIT_CARD", "NONE"],
           "description": "Configures the payment processor to be used for manual or autopay payments. This cannot be set to a value different from `NONE` if no valid ACH or Debit Card configs are provided.",


### PR DESCRIPTION

## Description of the change

> Remove repay_configs from required, change default payment method field name

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
