### PR TITLE
Thought default old product

### DIFF
--- a/dist/consolidated.json
+++ b/dist/consolidated.json
@@ -769,8 +769,9 @@
                   "effective_at": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "The `Date-Time` as of which this product is effective on the server.",
-                    "example": "2016-11-27T13:19:56+00:00"
+                    "description": "The `Date-Time` as of which this product is effective on the server. Your product should be older than all accounts enrolled in it.",
+                    "example": "2016-11-27T13:19:56+00:00",
+                    "default": "1900-01-01T12:00:00+00:00"
                   },
                   "external_product_id": {
                     "type": "string",
@@ -13756,8 +13757,9 @@
           "effective_at": {
             "type": "string",
             "format": "date-time",
-            "description": "The `Date-Time` as of which this product is effective on the server.",
-            "example": "2016-11-27T13:19:56+00:00"
+            "description": "The `Date-Time` as of which this product is effective on the server. Your product should be older than all accounts enrolled in it.",
+            "example": "2016-11-27T13:19:56+00:00",
+            "default": "1900-01-01T12:00:00+00:00"
           },
           "external_product_id": {
             "type": "string",
@@ -16482,8 +16484,9 @@
                 "effective_at": {
                   "type": "string",
                   "format": "date-time",
-                  "description": "The `Date-Time` as of which this product is effective on the server.",
-                  "example": "2016-11-27T13:19:56+00:00"
+                  "description": "The `Date-Time` as of which this product is effective on the server. Your product should be older than all accounts enrolled in it.",
+                  "example": "2016-11-27T13:19:56+00:00",
+                  "default": "1900-01-01T12:00:00+00:00"
                 },
                 "external_product_id": {
                   "type": "string",

--- a/schemas/CreateProductInput.json
+++ b/schemas/CreateProductInput.json
@@ -6,8 +6,9 @@
     "effective_at": {
       "type": "string",
       "format": "date-time",
-      "description": "The `Date-Time` as of which this product is effective on the server.",
-      "example": "2016-11-27T13:19:56+00:00"
+      "description": "The `Date-Time` as of which this product is effective on the server. Your product should be older than all accounts enrolled in it.",
+      "example": "2016-11-27T13:19:56+00:00",
+      "default": "1900-01-01T12:00:00+00:00"
     },
     "external_product_id": {
       "type": "string",

--- a/types/go/CreateProductInput.go
+++ b/types/go/CreateProductInput.go
@@ -1,6 +1,6 @@
 type CreateProductInput struct {
 	Admin                    *Admin                   `json:"admin,omitempty"`              
-	EffectiveAt              *string                  `json:"effective_at,omitempty"`       // The `Date-Time` as of which this product is effective on the server.
+	EffectiveAt              *string                  `json:"effective_at,omitempty"`       // The `Date-Time` as of which this product is effective on the server. Your product should; be older than all accounts enrolled in it.
 	ExternalProductID        *string                  `json:"external_product_id,omitempty"`// A unique external ID that may be used interchangeably with the Canopy-generated product ID
 	PostPromotionalPolicies  PostPromotionalPolicies  `json:"post_promotional_policies"`    
 	ProductLifecyclePolicies ProductLifecyclePolicies `json:"product_lifecycle_policies"`   

--- a/types/ts/CreateProductInput.type.ts
+++ b/types/ts/CreateProductInput.type.ts
@@ -1,7 +1,8 @@
 export interface CreateProductInput {
     admin?: Admin;
     /**
-     * The `Date-Time` as of which this product is effective on the server.
+     * The `Date-Time` as of which this product is effective on the server. Your product should
+     * be older than all accounts enrolled in it.
      */
     effective_at?: string;
     /**


### PR DESCRIPTION
@dangdennis -- would like your opinion on this;

product effective at dates are kind of odd tbh -- i'm thinking about defaulting them to 1900 so new accounts will always be more current. Don't want people to run into error:

"account must be older than product"