### PR TITLE
CI: upgrade bump-sh github-action to latest v1 version

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,10 +4,14 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   deploy:
-    name: deploy
+    if: ${{ github.event_name == 'push' }}
+    name: deploy documentation on push to master
     runs-on: ubuntu-latest
     steps:
       - name: Check out latest code
@@ -27,8 +31,39 @@ jobs:
         run: yarn build
 
       - name: Deploy to internal documentation
-        uses: bump-sh/github-action@0.2
+        uses: bump-sh/github-action@v1
         with:
           doc: ${{ secrets.BUMP_DOC_ID_INTERNAL }}
           token: ${{ secrets.BUMP_TOKEN_INTERNAL }}
           file: dist/consolidated.json
+
+  api-diff:
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+    name: Check API diff on pull requests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out latest code
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install node_modules
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn
+
+      - name: Bundle and validate OpenAPI spec
+        run: yarn build
+
+      - name: Check API diff with internal documentation
+        uses: bump-sh/github-action@v1
+        with:
+          doc: ${{ secrets.BUMP_DOC_ID_INTERNAL }}
+          token: ${{ secrets.BUMP_TOKEN_INTERNAL }}
+          file: dist/consolidated.json
+          command: diff
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -27,7 +27,7 @@ jobs:
         run: yarn build
 
       - name: Deploy to docs.canopyservicing.com
-        uses: bump-sh/github-action@0.2
+        uses: bump-sh/github-action@v1
         with:
           doc: ${{ secrets.BUMP_DOC_ID_LIVE }}
           token: ${{ secrets.BUMP_TOKEN_LIVE }}

--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -27,7 +27,7 @@ jobs:
         run: yarn build
 
       - name: Deploy uat docs
-        uses: bump-sh/github-action@0.2
+        uses: bump-sh/github-action@v1
         with:
           doc: ${{ secrets.BUMP_DOC_ID_UAT }}
           token: ${{ secrets.BUMP_TOKEN_UAT }}


### PR DESCRIPTION
Hey folks,

At Bump, we've recently released our [latest `v1` version](https://github.com/bump-sh/github-action/releases/tag/v1.0.0) of our
`bump-sh/github-action` which includes a new feature which runs on
pull requests: an API Diff comment which is published to any upstream
pull requests making a change to your contract.

We thought you would be interested to test it out 🙂. Here's a small
blog post about why we think checking API changes during development
is important: https://bump.sh/blog/api-design-first-with-bump-diff

Let us know what you think, and if you have any question I'd be happy
to help.

👋

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request